### PR TITLE
Potential fix for code scanning alert no. 3: Inefficient regular expression

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -3170,7 +3170,7 @@ d-citation-list .references .title {
         var def = {};
         def[tagName] = {
           pattern: RegExp(
-            /(<__[\s\S]*?>)(?:<!\[CDATA\[[\s\S]*?\]\]>\s*|[\s\S])*?(?=<\/__>)/.source.replace(/__/g, function () {
+            /(<__[^>]*?>)(?:<!\[CDATA\[[\s\S]*?\]\]>\s*|[^<])*?(?=<\/__>)/.source.replace(/__/g, function () {
               return tagName;
             }),
             "i"


### PR DESCRIPTION
Potential fix for [https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/3](https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/3)

To fix the problem, we need to modify the regular expression to remove the ambiguity that causes exponential backtracking. Specifically, we should replace the `[\s\S]*?` pattern with a more specific and efficient pattern that achieves the same functionality without causing performance issues.

The best way to fix this is to use a non-greedy match for any character except the closing tag, which can be done by using a negated character class. This approach ensures that the regular expression engine does not backtrack excessively.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
