### PR TITLE
Potential fix for code scanning alert no. 9: Inefficient regular expression

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -3170,7 +3170,7 @@ d-citation-list .references .title {
         var def = {};
         def[tagName] = {
           pattern: RegExp(
-            /(<__[^>]*?>)(?:<!\[CDATA\[[\s\S]*?\]\]>\s*|[^<])*?(?=<\/__>)/.source.replace(/__/g, function () {
+            /(<__[^>]*?>)(?:<!\[CDATA\[[\s\S]*?\]\]>\s+|[^<])*?(?=<\/__>)/.source.replace(/__/g, function () {
               return tagName;
             }),
             "i"


### PR DESCRIPTION
Potential fix for [https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/9](https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/9)

To fix the problem, we need to modify the regular expression to remove the ambiguity that causes exponential backtracking. Specifically, we should replace the `\s*` part of the regular expression with a more precise pattern that avoids ambiguity.

- In general terms, we should avoid using ambiguous patterns like `\s*` within repetitions that can match the same string in multiple ways.
- The best way to fix this specific issue is to replace `\s*` with a pattern that matches whitespace characters in a non-ambiguous way.
- We will change the regular expression on line 3173 in the file `assets/js/distillpub/template.v2.js`.
- No additional methods, imports, or definitions are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
