### PR TITLE
Potential fix for code scanning alert no. 11: Inefficient regular expression

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -3170,7 +3170,7 @@ d-citation-list .references .title {
         var def = {};
         def[tagName] = {
           pattern: RegExp(
-            /(<__[^>]*?>)(?:<!\[CDATA\[[\s\S]*?\]\]>\s+|[^<])*?(?=<\/__>)/.source.replace(/__/g, function () {
+            /(<__[^>]*?>)(?:<!\[CDATA\[[\s\S]*?\]\]>|[^<]|\s)+?(?=<\/__>)/.source.replace(/__/g, function () {
               return tagName;
             }),
             "i"


### PR DESCRIPTION
Potential fix for [https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/11](https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/11)

To fix the problem, we need to modify the regular expression to remove the ambiguity that causes exponential backtracking. This can be achieved by making the sub-expression more specific and less ambiguous. In this case, we can replace the `\s+` with a more specific pattern that avoids ambiguity.

The best way to fix the problem without changing existing functionality is to replace the `\s+` with a pattern that matches whitespace characters in a non-ambiguous way. We can use `(?:\s|<!\[CDATA\[[\s\S]*?\]\]>)+` to achieve this.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
