### PR TITLE
Potential fix for code scanning alert no. 13: Inefficient regular expression

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -3170,7 +3170,7 @@ d-citation-list .references .title {
         var def = {};
         def[tagName] = {
           pattern: RegExp(
-            /(<__[^>]*?>)(?:<!\[CDATA\[[\s\S]*?\]\]>|[^<]|\s)+?(?=<\/__>)/.source.replace(/__/g, function () {
+            /(<__[^>]*?>)(?:<!\[CDATA\[(?:[^<]|\s)*?\]\]>|[^<]|\s)+?(?=<\/__>)/.source.replace(/__/g, function () {
               return tagName;
             }),
             "i"


### PR DESCRIPTION
Potential fix for [https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/13](https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/13)

To fix the problem, we need to modify the regular expression to remove the ambiguity that causes exponential backtracking. Specifically, we should replace the `[\s\S]*?` pattern with a more specific and less ambiguous pattern. One way to achieve this is to use a negated character class that matches any character except the closing sequence we are looking for.

- Replace `[\s\S]*?` with `(?:[^<]|\s)*?` to ensure that we are not matching the closing sequence within the non-greedy repetition.
- This change will be made in the regular expression on line 3173 of the file `assets/js/distillpub/template.v2.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
