### PR TITLE
Potential fix for code scanning alert no. 15: Inefficient regular expression

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -3170,7 +3170,7 @@ d-citation-list .references .title {
         var def = {};
         def[tagName] = {
           pattern: RegExp(
-            /(<__[^>]*?>)(?:<!\[CDATA\[(?:[^<]|\s)*?\]\]>|[^<]|\s)+?(?=<\/__>)/.source.replace(/__/g, function () {
+            /(<__[^>]*?>)(?:<!\[CDATA\[[^<\s]*\s*\]\]>|[^<\s]*\s*)+?(?=<\/__>)/.source.replace(/__/g, function () {
               return tagName;
             }),
             "i"


### PR DESCRIPTION
Potential fix for [https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/15](https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/15)

To fix the problem, we need to remove the ambiguity in the regular expression by making the pattern more specific. Instead of using `(?:[^<]|\s)*?`, we can use a more precise pattern that avoids the ambiguity between matching spaces and other characters. We can replace `(?:[^<]|\s)*?` with `[^<\s]*\s*`, which separates the matching of non-space characters and spaces, thus eliminating the ambiguity.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
