### PR TITLE
Potential fix for code scanning alert no. 6: Prototype-polluting assignment

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -2692,13 +2692,13 @@ d-citation-list .references .title {
         },
 
         tokenize: function (text, grammar) {
-          var rest = grammar.rest;
+          var rest = grammar.get('rest');
           if (rest) {
-            for (var token in rest) {
-              grammar[token] = rest[token];
-            }
+            rest.forEach((value, key) => {
+              grammar.set(key, value);
+            });
 
-            delete grammar.rest;
+            grammar.delete('rest');
           }
 
           var tokenList = new LinkedList();
@@ -3019,7 +3019,8 @@ d-citation-list .references .title {
                 code = message.code,
                 immediateClose = message.immediateClose;
 
-              _self.postMessage(_.highlight(code, _.languages[lang], lang));
+              var grammar = new Map(Object.entries(_.languages[lang]));
+              _self.postMessage(_.highlight(code, grammar, lang));
               if (immediateClose) {
                 _self.close();
               }


### PR DESCRIPTION
Potential fix for [https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/6](https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/6)

To fix the prototype pollution vulnerability, we need to ensure that user-controlled input cannot modify `Object.prototype`. This can be achieved by using a `Map` object instead of a plain object for the `grammar` assignments, or by explicitly checking for and rejecting dangerous property names like `__proto__`, `constructor`, and `prototype`.

The best way to fix this without changing existing functionality is to use a `Map` object for the `grammar` assignments. This approach avoids the risk of prototype pollution entirely.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
