### PR TITLE
Potential fix for code scanning alert no. 4: Inefficient regular expression

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -3343,7 +3343,7 @@ d-citation-list .references .title {
     Prism.languages.insertBefore("javascript", "keyword", {
       regex: {
         pattern:
-          /((?:^|[^$\w\xA0-\uFFFF."'\])\s])\s*)\/(?:\[(?:[^\]\\\r\n]|\\.)*]|\\.|[^/\\\[\r\n])+\/[gimyus]{0,6}(?=(?:\s|\/\*[\s\S]*?\*\/)*(?:$|[\r\n,.;:})\]]|\/\/))/,
+          /((?:^|[^$\w\xA0-\uFFFF."'\])\s])\s*)\/(?:\[(?:[^\]\\\r\n]|\\.)*]|\\.|[^/\\\[\r\n])+\/[gimyus]{0,6}(?=(?:\s|\/\*(?:[^*]|\*(?!\/))*\*\/)*(?:$|[\r\n,.;:})\]]|\/\/))/,
         lookbehind: true,
         greedy: true,
       },


### PR DESCRIPTION
Potential fix for [https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/4](https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/4)

To resolve the inefficiency and reduce ambiguity in the regular expression, the offending pattern `[\s\S]*?` (used within the `/\/\*[\s\S]*?\*\//` portion) should be replaced with a less ambiguous alternative that does not allow matching many "/*" or "*/" delimiters with overlapping greedy matches. The standard idiom for matching balanced comment blocks is to use a negated character class that matches anything except the end delimiter, i.e., match anything except `*` or match `(?!\*/)`, thus: `/\/\*[^]*?\*\//` or, for greater safety, `/\/\*[^*]*\*+([^/*][^*]*\*+)*/\//` (the classic block comment regex). 

However, since in JavaScript regex there is no dotall (`s`) mode in legacy environments, `[\s\S]` is used to match any character, including newline. But the key is to avoid allowing matches of multiple `*//*` inside the block to encourage linear matching.

Thus, replace `[\s\S]*?` with `(?:[^*]|\*(?!\/))*`, which matches any sequence of characters that are not `*`, or the character `*` only if it is not followed by `/` (i.e., not the closing delimiter).

Apply this change to the regular expression on line 3346 within file `assets/js/distillpub/template.v2.js`.

No new imports or dependencies are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
