### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete string escaping or encoding

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -4235,7 +4235,7 @@ ${css}
 
       if (this.hasAttribute("block")) {
         // normalize the tab indents
-        content = content.replace(/\n/, "");
+        content = content.replace(/\n/g, "");
         const tabs = content.match(/\s*/);
         content = content.replace(new RegExp("\n" + tabs, "g"), "\n");
         content = content.trim();


### PR DESCRIPTION
Potential fix for [https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/7](https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/7)

To fix the problem, we should change the regex in `content.replace(/\n/, "")` to ensure that all relevant occurrences are replaced—not just the first. The best fix is to add the `g` (global) flag for the regular expression, making it `/\n/g`, which will replace all newline characters in `content`. Only this line needs editing. No imports or extra definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
