### PR TITLE
Potential fix for code scanning alert no. 2: Inefficient regular expression

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -3170,7 +3170,7 @@ d-citation-list .references .title {
         var def = {};
         def[tagName] = {
           pattern: RegExp(
-            /(<__[\s\S]*?>)(?:<!\[CDATA\[[\s\S]*?\]\]>\s*|[\s\S])*?(?=<\/__>)/.source.replace(/__/g, function () {
+            /(<__[\s\S]*?>)(?:<!\[CDATA\[[\s\S]*?\]\]>\s*|(?:(?!<!\[CDATA\[)[\s\S]))*?(?=<\/__>)/.source.replace(/__/g, function () {
               return tagName;
             }),
             "i"


### PR DESCRIPTION
Potential fix for [https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/2](https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/2)

To fix the problem, we should make the alternation inside the group non-ambiguous. The current alternation is `(?:<!\[CDATA\[[\s\S]*?\]\]>\s*|[\s\S])*?`, where `|[\s\S]` means that *any character* is a match—so the regex engine must check both options at every position. The fix is to **exclude CDATA sequences from the "any character" branch**, so that the two alternatives cannot match the same input.

How to do this:
- Replace `[\s\S]` in the alternation with a negative lookahead that skips CDATA sections. For example, `(?:<!\[CDATA\[[\s\S]*?\]\]>\s*|(?:(?!<!\[CDATA\[)[\s\S]))*?`.
    - Here, `(?:(?!<!\[CDATA\[)[\s\S])` matches any character that is *not* the start of a CDATA section.
    - This ensures that the first branch handles CDATA tags, and the second branch handles everything else without overlapping.
- Only modify the affected regular expression in the file assets/js/distillpub/template.v2.js, at line 3173.
- No extra dependencies or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
