### PR TITLE
Potential fix for code scanning alert no. 4: Inefficient regular expression

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -3342,7 +3342,7 @@ d-citation-list .references .title {
       },
       parameter: [
         {
-          pattern: /(function(?:\s+[_$A-Za-z\xA0-\uFFFF][$\w\xA0-\uFFFF]*)?\s*\(\s*)(?!\s)(?:[^()]|\([^()]*\))+?(?=\s*\))/,
+          pattern: /(function(?:\s+[_$A-Za-z\xA0-\uFFFF][$\w\xA0-\uFFFF]*)?\s*\(\s*)(?!\s)[^)]*(?=\s*\))/,
           lookbehind: true,
           inside: Prism.languages.javascript,
         },


### PR DESCRIPTION
Potential fix for [https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/4](https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/4)

**General solution:**
To fix inefficient regexes causing exponential backtracking, you need to remove ambiguous alternations and "nested star" constructs (e.g., `(?:a|b)*`, `(.|ab)*`, etc.), especially inside a loop. Instead, use non-ambiguous quantifiers or more precise matching when parsing patterns like nested parentheses.

**Detailed plan:**
- The most problematic part is `(?:[^()]|\([^()]*\))+?`, which tries to parse arbitrary parentheses but cannot handle nesting, and is exponential for long repeated structures.
- The pragmatic fix is to limit the parameter list to not handle deep nesting (as the current regex doesn't really support full balanced parentheses anyway), or to refactor it to use a non-exponential structure.
- In syntax highlighters, a common compromise is to avoid nested parsing and instead match until the first closing parenthesis. Therefore, replace this with a pattern that never backtracks exponentially, such as matching any character except `)` or `(` (optionally treating one level of parentheses if needed).
- The **recommended fix** is to use a pattern matching any non-parenthesis character or a parenthesis-enclosed group without recursion, for example: `(?:[^()]|\([^()]*\))*`,
  *but not with nested quantifiers or ambiguous alternation*.
- The best option for most syntax highlighters is to use a simple non-greedy match up to the first closing parentheses or a safe character class: `[^)]*` or (if you must match for commas and other arg separators) `[^\)]*`.

**What to change:**
- In file `assets/js/distillpub/template.v2.js`, replace line 3345's pattern:
  ```
  pattern: /(function(?:\s+[_$A-Za-z\xA0-\uFFFF][$\w\xA0-\uFFFF]*)?\s*\(\s*)(?!\s)(?:[^()]|\([^()]*\))+?(?=\s*\))/,
  ```
  with a safer alternative:
  ```
  pattern: /(function(?:\s+[_$A-Za-z\xA0-\uFFFF][$\w\xA0-\uFFFF]*)?\s*\(\s*)(?!\s)[^)]*(?=\s*\))/,
  ```
- This matches the parameter list up to the next closing parenthesis, with no ambiguous alternation or nested optional quantifiers.

No new imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
