### PR TITLE
Potential fix for code scanning alert no. 18: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -4672,6 +4672,16 @@ d-references {
   <h2>Table of contents</h2>
   <ul>`;
 
+    // Helper to escape HTML special characters
+    function escapeHTML(str) {
+      return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
     for (const el of headings) {
       // should element be included in TOC?
       const isInTitle = el.parentElement.tagName == "D-TITLE";
@@ -4681,7 +4691,7 @@ d-references {
       const title = el.textContent;
       const link = "#" + el.getAttribute("id");
 
-      let newLine = "<li>" + '<a href="' + link + '">' + title + "</a>" + "</li>";
+      let newLine = "<li>" + '<a href="' + link + '">' + escapeHTML(title) + "</a>" + "</li>";
       if (el.tagName == "H3") {
         newLine = "<ul>" + newLine + "</ul>";
       } else {


### PR DESCRIPTION
Potential fix for [https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/18](https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/18)

To fix this vulnerability, you should escape special HTML characters (`&`, `<`, `>`, `"`, `'`) from the `title` variable before inserting it into the HTML string. This can be achieved by passing `title` through a simple HTML escaping function before use. You need to:
- Add an `escapeHTML` helper function, if one does not already exist.
- Replace the use of `title` in the string concatenation at line 4684 with `escapeHTML(title)`.
- Ensure `escapeHTML` is defined within the relevant scope (local helper or top-level if reused).

No functionality will change: only the process of embedding `title` within the built HTML will now escape meta-characters, making this safe against XSS.

Modifications are only required in `assets/js/distillpub/template.v2.js`, specifically in the code handling generation of the Table of Contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
