### PR TITLE
Potential fix for code scanning alert no. 6: Prototype-polluting assignment

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -2695,6 +2695,13 @@ d-citation-list .references .title {
           var rest = grammar.rest;
           if (rest) {
             for (var token in rest) {
+              if (
+                token === "__proto__" ||
+                token === "constructor" ||
+                token === "prototype"
+              ) {
+                continue;
+              }
               grammar[token] = rest[token];
             }
 


### PR DESCRIPTION
Potential fix for [https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/6](https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/6)

To fix this prototype pollution vulnerability, we should sanitize the keys in the `rest` object before assigning them to `grammar`. Specifically, we must skip assignments for problematic property names: `"__proto__"`, `"constructor"`, and `"prototype"`. This can be done by adding a guard within the `for...in` loop in the `tokenize` function such that if a key matches any of these dangerous property names, we do not assign it to `grammar`. The edit is localized and does not affect existing functionality for legitimate keys.

- **Where:** Within the file `assets/js/distillpub/template.v2.js`, at/around line 2697 where keys from `rest` are assigned to `grammar`.
- **How:** Insert a conditional statement (`if`) inside the `for...in` loop to skip dangerous keys.

No third-party libraries are necessary for this simple key check; standard JavaScript suffices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
