### PR TITLE
Potential fix for code scanning alert no. 5: Prototype-polluting assignment

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -2694,6 +2694,17 @@ d-citation-list .references .title {
         tokenize: function (text, grammar) {
           var rest = grammar.rest;
           if (rest) {
+            // If grammar is not a prototype-less object, convert it.
+            if (Object.getPrototypeOf(grammar) !== null) {
+              var newGrammar = Object.create(null);
+              // Copy old grammar's own properties except 'rest'
+              for (var k in grammar) {
+                if (grammar.hasOwnProperty(k) && k !== 'rest') {
+                  newGrammar[k] = grammar[k];
+                }
+              }
+              grammar = newGrammar;
+            }
             for (var token in rest) {
               if (
                 token === "__proto__" ||


### PR DESCRIPTION
Potential fix for [https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/5](https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/5)

To robustly fix this prototype pollution risk:
- The best remedy is to avoid assigning untrusted keys directly to regular objects. Use an object that is not susceptible to prototype pollution—specifically, a prototype-less object via `Object.create(null)` for `grammar`, or switch to an ES6 `Map` for all grammar-related assignments. This prevents special keys like `__proto__`, `constructor`, or `prototype` from modifying the prototype chain, even if passed as input.
- Changing `grammar[token] = rest[token];` to operate on a prototype-less object, and ensuring that `grammar` itself is created using `Object.create(null)` (or as a `Map`), but to minimize disruption, we only need to ensure `grammar` is replaced with a prototype-less object when we populate it from `rest`.
- Specifically, replace:
  - Inside the `tokenize` function: before assigning properties from `rest` to `grammar`, check if `grammar` is a plain object. If so, create a prototype-less copy and assign its keys as needed.
  - This change takes place within the shown region of the code, inside the `tokenize: function (text, grammar) { ... }` block. No extra imports are required in browser JavaScript.

This approach maintains existing functionality but eliminates prototype pollution risks when extending grammars.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
