### PR TITLE
Potential fix for code scanning alert no. 4: Inefficient regular expression

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -3343,7 +3343,7 @@ d-citation-list .references .title {
       operator: /--|\+\+|\*\*=?|=>|&&|\|\||[!=]==|<<=?|>>>?=?|[-+*/%&|^!=<>]=?|\.{3}|\?[.?]?|[~:]/,
     });
 
-    Prism.languages.javascript["class-name"][0].pattern = /(\b(?:class|interface|extends|implements|instanceof|new)\s+)[\w.\\]+/;
+    Prism.languages.javascript["class-name"][0].pattern = /(\b(?:class|interface|extends|implements|instanceof|new)\s+)[\w]+(?:[.\\][\w]+)*/;
 
     Prism.languages.insertBefore("javascript", "keyword", {
       regex: {


### PR DESCRIPTION
Potential fix for [https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/4](https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/4)

To fix the problem, we should rewrite the character class `[\w.\\]+` to remove potential ambiguity caused by overlapping character possibilities resulting from the inclusion of `\w` and `.` and `\`. It's better to write a pattern that precisely expresses what a qualified JS class name can be.

Since class names in JS can be sequences of identifier names joined by `.` or `\` (the latter seems questionable but is copied from the original, perhaps to support namespaced identifiers), we can:
- Replace `[\w.\\]+` with something like `[\w]+(?:[.\\][\w]+)*`
- This means: a sequence of identifier chars, optionally followed by repeated (`.` or `\`) and more identifier chars.  
This eliminates ambiguous parses (e.g., whether "a.b" is parsed as ("a", ".", "b") or ("a.", "b")), disallowing empty sections and thus exponential ambiguity.

No new imports or external definitions are needed. Change only the regex pattern at line 3346 (`Prism.languages.javascript["class-name"][0].pattern`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
