### PR TITLE
Potential fix for code scanning alert no. 4: Inefficient regular expression

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -3343,7 +3343,7 @@ d-citation-list .references .title {
       operator: /--|\+\+|\*\*=?|=>|&&|\|\||[!=]==|<<=?|>>>?=?|[-+*/%&|^!=<>]=?|\.{3}|\?[.?]?|[~:]/,
     });
 
-    Prism.languages.javascript["class-name"][0].pattern = /(\b(?:class|interface|extends|implements|instanceof|new)\s+)[\w]+(?:[.\\][\w]+)*/;
+    Prism.languages.javascript["class-name"][0].pattern = /(\b(?:class|interface|extends|implements|instanceof|new)\s+)[\w]+([.\\][\w]+)*/;
 
     Prism.languages.insertBefore("javascript", "keyword", {
       regex: {


### PR DESCRIPTION
Potential fix for [https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/4](https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/4)

To fix the problem:
- The ambiguity arises because `[\w]+` and `(?:[.\\][\w]+)` overlap in the way they can match string sequences. Specifically, a string segment like `a.a.a` can be matched as a single run of `[\w]+`, or as alternating `.`, then another run of `[\w]+`.
- To remove ambiguity, rewrite the regex so that inside the repetition, at each step of matching an element, there is no way for a substring to be matched by multiple alternatives.
- Specifically, instead of using `[\w]+(?:[.\\][\w]+)*` to match something like `foo.bar.baz`, use something like `[\w]+(?:[.\\][\w]+)*`, but change the first subgroup so that it is unambiguously the first element, and force each subsequent element to start with dot or backslash followed by word characters.
- Even better, match the entire thing as `[\w]+([.\\][\w]+)*`, i.e., one run of word characters, followed by zero or more dot/backslash+word characters.
- Thus, the fix uses `[\w]+([.\\][\w]+)*` instead of `[\w]+(?:[.\\][\w]+)*`.

Edit the regex at line 3346 of `assets/js/distillpub/template.v2.js` (the `pattern` property of `Prism.languages.javascript["class-name"][0]`).

No imports or new dependencies required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
