### PR TITLE
Potential fix for code scanning alert no. 4: Inefficient regular expression

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -3343,7 +3343,7 @@ d-citation-list .references .title {
       operator: /--|\+\+|\*\*=?|=>|&&|\|\||[!=]==|<<=?|>>>?=?|[-+*/%&|^!=<>]=?|\.{3}|\?[.?]?|[~:]/,
     });
 
-    Prism.languages.javascript["class-name"][0].pattern = /(\b(?:class|interface|extends|implements|instanceof|new)\s+)[\w]+([.\\][\w]+)*/;
+    Prism.languages.javascript["class-name"][0].pattern = /(\b(?:class|interface|extends|implements|instanceof|new)\s+)[\w]+(?:[.\\][\w]+)*/;
 
     Prism.languages.insertBefore("javascript", "keyword", {
       regex: {


### PR DESCRIPTION
Potential fix for [https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/4](https://github.com/wchongmh/wchongmh.github.io/security/code-scanning/4)

The problem is in the `([.\\][\w]+)*` group: inside a repeated group (`*`), where `[.\\][\w]+` can match in overlapping ways with previous repetitions. For example, the dot or backslash *could* also be matched by the following `[.\\]`, or by the previous `[.\\]`, resulting in many possible ways to partition the input into repetitions, causing backtracking.

The most common fix is to replace the ambiguous repetition with an unambiguous one. In this case, we want to match a "qualified" identifier: e.g. `"Test.Foo.Bar"`, `"Test\Foo\Bar"`, etc. The classic way is to match an initial identifier, then zero or more times "dot or backslash + identifier", expressed as: 

`[\w]+([.\\][\w]+)*`

But, the standard solution is to replace the repeated group with a non-capturing group, and change `+` inside to be unambiguous: e.g., 
`[\w]+(?:[.\\][\w]+)*`

However, note the actual performance problem is in how the repeated `[.\\][\w]+` is parsed. The ambiguity can be removed by not matching `[.\\][\w]+` in ambiguous ways. One better, much less ambiguous alternative is:

- Match: one or more segments consisting of (dot or backslash) then one or more word characters, i.e. `(?:[.\\][\w]+)*`
- To avoid ambiguity, we try matching the fully qualified pattern as: 

  `\b(?:class|interface|extends|implements|instanceof|new)\s+[\w]+(?:[.\\][\w]+)*`

If capturing groups must be preserved for highlighting, preserve the existing captures except for ambiguous ones.

So, in summary, change
```
[\w]+([.\\][\w]+)*
```
to
```
[\w]+(?:[.\\][\w]+)*
```
to make the repeated group non-capturing and less ambiguous. Alternatively, use a more specific identifier regex for more safety, but the above is the minimal fix.

Make this change on line 3346.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
